### PR TITLE
Fixes coexistance with other templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Zabbix Pacemaker Template
+
 A Zabbix template for pacemaker cluster monitoring with virtual ip.
 
 Author: Vadim Ipatov <<vadim.ipatov@zabbix.com>> (<euphoria.vi@gmail.com>)
 
 ## Requires
+
 * Zabbix >=3.4 (because the template uses [dependent items](https://www.zabbix.com/documentation/3.4/manual/config/items/itemtypes/dependent_items) and [value preprocessing](https://www.zabbix.com/documentation/3.4/manual/config/items/item#item_value_preprocessing) features that were introduced in 3.4)
 
 ## Metrics
+
 | Metric                              | Description                                                                             |
 |-------------------------------------|-----------------------------------------------------------------------------------------|
 | pacemaker.cluster.dc                | Current cluster DC (Designated Coordinator)                                             |
@@ -17,10 +20,12 @@ Author: Vadim Ipatov <<vadim.ipatov@zabbix.com>> (<euphoria.vi@gmail.com>)
 | pacemaker.process.pacemakerd.active | Shows if pacemakerd daemon is in the running state                                      |
 | pacemaker.resources.failed          | The current number of failed (non active or blocked) resources                          |
 | pacemaker.status                    | Service item for data gathering                                                         |
-| system.hostname                     | Node hostname. If it changes, it could mean that the VIP has been moved to another node |
+| node.name                           | Node hostname. If it changes, it could mean that the VIP has been moved to another node |
 
 ## Installation
+
 You need to configure every cluster nodes as shown below:
+
 * Copy "configs/pacemaker.conf" into your zabbix_agent include folder (default: /etc/zabbix/zabbix_agentd.d/) or manually add that UserParameter to config:
 
 ```UserParameter=pacemaker.status, sudo /usr/sbin/crm_mon --as-xml```
@@ -35,7 +40,8 @@ You need to configure every cluster nodes as shown below:
 * Create "virtual" host object with virtual ip address as network interface and link this template.
 
 ## Testing
-You can check that everything works correctly by using crm_mon dumps in “tests” folder. 
+
+You can check that everything works correctly by using crm_mon dumps in “tests” folder.
 
 For this purpose you need to copy dumps to cluster nodes (or use your own) and add this UserParameter to config:
 

--- a/template_app_pacemaker.xml
+++ b/template_app_pacemaker.xml
@@ -394,11 +394,11 @@
                     <master_item/>
                 </item>
                 <item>
-                    <name>system.hostname</name>
+                    <name>node.name</name>
                     <type>0</type>
                     <snmp_community/>
                     <snmp_oid/>
-                    <key>system.hostname</key>
+                    <key>node.name</key>
                     <delay>5s</delay>
                     <history>7d</history>
                     <trends>0</trends>
@@ -552,7 +552,7 @@
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Template App Pacemaker:system.hostname.diff(0)}=1</expression>
+            <expression>{Template App Pacemaker:node.name.diff(0)}=1</expression>
             <recovery_mode>2</recovery_mode>
             <recovery_expression/>
             <name>{HOST.NAME}/pacemaker: Probably cluster migration detected (hostname was changed)</name>


### PR DESCRIPTION
This PR fixes an issue with conflicting key `system.hostname` (mostly used by Linux by Zabbix Agent).